### PR TITLE
write code in xmap with kimi-k2-0711-preview

### DIFF
--- a/pkg/xmap/README.md
+++ b/pkg/xmap/README.md
@@ -15,6 +15,8 @@ import "github.com/dashjay/xiter/pkg/xmap"
 - [func EqualFunc\[M1 \~map\[K\]V1, M2 \~map\[K\]V2, K comparable, V1, V2 any\]\(m1 M1, m2 M2, eq func\(V1, V2\) bool\) bool](<#EqualFunc>)
 - [func Filter\[M \~map\[K\]V, K comparable, V any\]\(in M, fn func\(K, V\) bool\) M](<#Filter>)
 - [func Keys\[M \~map\[K\]V, K comparable, V any\]\(m M\) \[\]K](<#Keys>)
+- [func MapKeys\[K comparable, V1 any\]\(in map\[K\]V1, fn func\(K, V1\) K\) map\[K\]V1](<#MapKeys>)
+- [func MapValues\[K comparable, V1, V2 any\]\(in map\[K\]V1, fn func\(K, V1\) V2\) map\[K\]V2](<#MapValues>)
 - [func ToUnionSlice\[M \~map\[K\]V, K comparable, V any\]\(m M\) \[\]union.U2\[K, V\]](<#ToUnionSlice>)
 - [func Values\[M \~map\[K\]V, K comparable, V any\]\(m M\) \[\]V](<#Values>)
 
@@ -116,6 +118,72 @@ func Keys[M ~map[K]V, K comparable, V any](m M) []K
 ```
 
 
+
+<a name="MapKeys"></a>
+## func [MapKeys](<https://github.com/dashjay/xiter/blob/main/pkg/xmap/xmap_common.go#L96>)
+
+```go
+func MapKeys[K comparable, V1 any](in map[K]V1, fn func(K, V1) K) map[K]V1
+```
+
+MapKeys transforms the keys of a map using the provided function while keeping values unchanged. This is useful for transforming data structures while preserving the value associations.
+
+Parameters:
+
+```
+in map[K]V1: The input map to transform
+fn func(K, V1) K: A function that takes a key and its corresponding value, and returns a new key
+```
+
+Returns:
+
+```
+map[K]V1: A new map with the same values as the input map but with transformed keys
+```
+
+Example:
+
+```
+m := map[string]int{"a": 1, "b": 2, "c": 3}
+fn := func(k string, v int) string {
+	return k + "_key"
+}
+result := MapKeys(m, fn)
+// result will be map[string]int{"a_key": 1, "b_key": 2, "c_key": 3}
+```
+
+<a name="MapValues"></a>
+## func [MapValues](<https://github.com/dashjay/xiter/blob/main/pkg/xmap/xmap_common.go#L72>)
+
+```go
+func MapValues[K comparable, V1, V2 any](in map[K]V1, fn func(K, V1) V2) map[K]V2
+```
+
+MapValues transforms the values of a map using the provided function while keeping keys unchanged. This is useful for transforming data structures while preserving the key associations.
+
+Parameters:
+
+```
+in M: The input map to transform
+fn func(K, V1) V2: A function that takes a key and its corresponding value, and returns a new value
+```
+
+Returns:
+
+```
+map[K]V2: A new map with the same keys as the input map but with transformed values
+```
+
+Example:
+
+```
+m := map[string]int{"a": 1, "b": 2, "c": 3}
+fn := func(k string, v int) string {
+	return fmt.Sprintf("value_%d", v)
+}
+result := MapValues(m, fn)
+// result will be map[string]string{"a": "value_1", "b": "value_2", "c": "value_3"}
+```
 
 <a name="ToUnionSlice"></a>
 ## func [ToUnionSlice](<https://github.com/dashjay/xiter/blob/main/pkg/xmap/xmap.go#L37>)

--- a/pkg/xmap/xmap_common.go
+++ b/pkg/xmap/xmap_common.go
@@ -48,3 +48,51 @@ func CoalesceMaps[M ~map[K]V, K comparable, V any](maps ...M) M {
 func Filter[M ~map[K]V, K comparable, V any](in M, fn func(K, V) bool) M {
 	return xiter.ToMap(xiter.Filter2(fn, xiter.FromMapKeyAndValues(in)))
 }
+
+// MapValues transforms the values of a map using the provided function while keeping keys unchanged.
+// This is useful for transforming data structures while preserving the key associations.
+//
+// Parameters:
+//
+//	in M: The input map to transform
+//	fn func(K, V1) V2: A function that takes a key and its corresponding value, and returns a new value
+//
+// Returns:
+//
+//	map[K]V2: A new map with the same keys as the input map but with transformed values
+//
+// Example:
+//
+//	m := map[string]int{"a": 1, "b": 2, "c": 3}
+//	fn := func(k string, v int) string {
+//		return fmt.Sprintf("value_%d", v)
+//	}
+//	result := MapValues(m, fn)
+//	// result will be map[string]string{"a": "value_1", "b": "value_2", "c": "value_3"}
+func MapValues[K comparable, V1, V2 any](in map[K]V1, fn func(K, V1) V2) map[K]V2 {
+	return xiter.ToMap(xiter.Map2(func(k K, v V1) (K, V2) { return k, fn(k, v) }, xiter.FromMapKeyAndValues(in)))
+}
+
+// MapKeys transforms the keys of a map using the provided function while keeping values unchanged.
+// This is useful for transforming data structures while preserving the value associations.
+//
+// Parameters:
+//
+//	in map[K]V1: The input map to transform
+//	fn func(K, V1) K: A function that takes a key and its corresponding value, and returns a new key
+//
+// Returns:
+//
+//	map[K]V1: A new map with the same values as the input map but with transformed keys
+//
+// Example:
+//
+//	m := map[string]int{"a": 1, "b": 2, "c": 3}
+//	fn := func(k string, v int) string {
+//		return k + "_key"
+//	}
+//	result := MapKeys(m, fn)
+//	// result will be map[string]int{"a_key": 1, "b_key": 2, "c_key": 3}
+func MapKeys[K comparable, V1 any](in map[K]V1, fn func(K, V1) K) map[K]V1 {
+	return xiter.ToMap(xiter.Map2(func(k K, v V1) (K, V1) { return fn(k, v), v }, xiter.FromMapKeyAndValues(in)))
+}

--- a/pkg/xmap/xmap_test.go
+++ b/pkg/xmap/xmap_test.go
@@ -87,4 +87,61 @@ func TestMap(t *testing.T) {
 		result := xmap.Filter(m, fn)
 		assert.True(t, xmap.Equal(result, _map(51, 100)))
 	})
+
+	t.Run("map values", func(t *testing.T) {
+		m := map[string]int{"a": 1, "b": 2, "c": 3}
+		fn := func(k string, v int) string {
+			return fmt.Sprintf("value_%d", v)
+		}
+		var result = xmap.MapValues(m, fn)
+		expected := map[string]string{"a": "value_1", "b": "value_2", "c": "value_3"}
+		assert.Equal(t, expected, result)
+
+		// Test with key usage in transformation
+		fnWithKey := func(k string, v int) string {
+			return fmt.Sprintf("%s_%d", k, v)
+		}
+		resultWithKey := xmap.MapValues(m, fnWithKey)
+		expectedWithKey := map[string]string{"a": "a_1", "b": "b_2", "c": "c_3"}
+		assert.Equal(t, expectedWithKey, resultWithKey)
+
+		// Test with empty map
+		emptyMap := map[string]int{}
+		emptyResult := xmap.MapValues(emptyMap, fn)
+		assert.Equal(t, map[string]string{}, emptyResult)
+	})
+
+	t.Run("map keys", func(t *testing.T) {
+		m := map[string]int{"a": 1, "b": 2, "c": 3}
+		fn := func(k string, v int) string {
+			return k + "_key"
+		}
+		var result = xmap.MapKeys(m, fn)
+		expected := map[string]int{"a_key": 1, "b_key": 2, "c_key": 3}
+		assert.Equal(t, expected, result)
+
+		// Test with value usage in transformation
+		fnWithValue := func(k string, v int) string {
+			return fmt.Sprintf("%s_%d", k, v)
+		}
+		resultWithValue := xmap.MapKeys(m, fnWithValue)
+		expectedWithValue := map[string]int{"a_1": 1, "b_2": 2, "c_3": 3}
+		assert.Equal(t, expectedWithValue, resultWithValue)
+
+		// Test with empty map
+		emptyMap := map[string]int{}
+		emptyResult := xmap.MapKeys(emptyMap, fn)
+		assert.Equal(t, map[string]int{}, emptyResult)
+
+		// Test with duplicate key generation (last one wins)
+		m2 := map[int]string{1: "a", 2: "b", 3: "c"}
+		fn2 := func(k int, v string) int {
+			return k % 2 // This will create duplicate keys: 1%2=1, 2%2=0, 3%2=1
+		}
+		result2 := xmap.MapKeys(m2, fn2)
+		// Should have keys 0 and 1, with values from the last occurrence of each key
+		expected2 := map[int]string{0: "b", 1: "c"}
+		assert.Equal(t, expected2, result2)
+	})
+
 }

--- a/pkg/xmap/xmap_test.go
+++ b/pkg/xmap/xmap_test.go
@@ -132,16 +132,7 @@ func TestMap(t *testing.T) {
 		emptyMap := map[string]int{}
 		emptyResult := xmap.MapKeys(emptyMap, fn)
 		assert.Equal(t, map[string]int{}, emptyResult)
-
-		// Test with duplicate key generation (last one wins)
-		m2 := map[int]string{1: "a", 2: "b", 3: "c"}
-		fn2 := func(k int, v string) int {
-			return k % 2 // This will create duplicate keys: 1%2=1, 2%2=0, 3%2=1
-		}
-		result2 := xmap.MapKeys(m2, fn2)
-		// Should have keys 0 and 1, with values from the last occurrence of each key
-		expected2 := map[int]string{0: "b", 1: "c"}
-		assert.Equal(t, expected2, result2)
+		
 	})
 
 }


### PR DESCRIPTION

# Summary: 


AI did a good job on this kind of codes
But kimi-k2-0711-preview made a mistake is that map in golang is unorderd 
so the testing function generated will not pass
```
       136 +      // Test with duplicate key generation (last one wins)
       137 +      m2 := map[int]string{1: "a", 2: "b", 3: "c"}
       138 +      fn2 := func(k int, v string) int {
       139 +        return k % 2 // This will create duplicate keys: 1%2=1, 2%2=0, 3%2=1
       140 +      }
       141 +      result2 := xmap.MapKeys(m2, fn2)
       142 +      // Should have keys 0 and 1, with values from the last occurrence of each key
       143 +      expected2 := map[int]string{0: "b", 1: "c"}
       144 +      assert.Equal(t, expected2, result2)
```

------

Tips for getting started:

 1. Run /init to create a CLAUDE.md file with instructions for Claude
 2. Run /terminal-setup to set up terminal integration
 3. Use Claude to help with file analysis, editing, bash commands and git
 4. Be as specific as you would with another engineer for the best results

> write a new function like MapValues[K comparable, V1, V2 any] in pkg/xmap/xmap_common.go but name MapKeys[K comparable, V1](in map[K]V1, fn func(K, V1) K)
  map[K]V1 which do things like  MapValues but on keys, and generate a test in pkg/xmap/xmap_test.go

⏺ I'll implement the MapKeys function and add tests for it. Let me start by examining the existing code to understand the pattern used in MapValues.

⏺ Read(pkg/xmap/xmap_common.go)
  ⎿  Read 75 lines (ctrl+r to expand)

⏺ Now let me look at the test file to understand the testing pattern:

⏺ Read(pkg/xmap/xmap_test.go)
  ⎿  Read 114 lines (ctrl+r to expand)

⏺ Now I'll implement the MapKeys function based on the existing MapValues pattern, and add tests for it.

⏺ Update(pkg/xmap/xmap_common.go)

╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Edit file                                                                                                                                                             │
│ ╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ │
│ │ pkg/xmap/xmap_common.go                                                                                                                                           │ │
│ │                                                                                                                                                                   │ │
│ │   72    func MapValues[K comparable, V1, V2 any](in map[K]V1, fn func(K, V1) V2)                                                                                  │ │

⏺ Update(pkg/xmap/xmap_common.go)

╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Edit file                                                                                                                                                             │
│ ╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ │
│ │ pkg/xmap/xmap_common.go                                                                                                                                           │ │
│ │                                                                                                                                                                   │ │
│ │   72    func MapValues[K comparable, V1, V2 any](in map[K]V1, fn func(K, V1) V2) map[K]V2 {                                                                       │ │

⏺ Update(pkg/xmap/xmap_common.go)
  ⎿  Updated pkg/xmap/xmap_common.go with 24 additions
       72    func MapValues[K comparable, V1, V2 any](in map[K]V1, fn func(K, V1) V2) map[K]V2 {
       73      return xiter.ToMap(xiter.Map2(func(k K, v V1) (K, V2) { return k, fn(k, v) }, xiter.FromMapKeyAndValues(in)))
       74    }
       75 +
       76 +  // MapKeys transforms the keys of a map using the provided function while keeping values unchanged.
       77 +  // This is useful for transforming data structures while preserving the value associations.
       78 +  //
       79 +  // Parameters:
       80 +  //
       81 +  //	in map[K]V1: The input map to transform
       82 +  //	fn func(K, V1) K: A function that takes a key and its corresponding value, and returns a new key
       83 +  //
       84 +  // Returns:
       85 +  //
       86 +  //	map[K]V1: A new map with the same values as the input map but with transformed keys
       87 +  //
       88 +  // Example:
       89 +  //
       90 +  //	m := map[string]int{"a": 1, "b": 2, "c": 3}
       91 +  //	fn := func(k string, v int) string {
       92 +  //		return k + "_key"
       93 +  //	}
       94 +  //	result := MapKeys(m, fn)
       95 +  //	// result will be map[string]int{"a_key": 1, "b_key": 2, "c_key": 3}
       96 +  func MapKeys[K comparable, V1 any](in map[K]V1, fn func(K, V1) K) map[K]V1 {
       97 +    return xiter.ToMap(xiter.Map2(func(k K, v V1) (K, V1) { return fn(k, v), v }, xiter.FromMapKeyAndValues(in)))
       98 +  }

⏺ Now I'll add tests for the new MapKeys function:

⏺ Update(pkg/xmap/xmap_test.go)
  ⎿  User rejected update to pkg/xmap/xmap_test.go
       110        emptyResult := xmap.MapValues(emptyMap, fn)
       111        assert.Equal(t, map[string]string{}, emptyResult)
       112      })
       113 +
       114 +    t.Run("map keys", func(t *testing.T) {
       115 +      m := map[string]int{"a": 1, "b": 2, "c": 3}
       116 +      fn := func(k string, v int) string {
       117 +        return k + "_key"
       118 +      }
       119 +      var result = xmap.MapKeys(m, fn)
       120 +      expected := map[string]int{"a_key": 1, "b_key": 2, "c_key": 3}
       121 +      assert.Equal(t, expected, result)
       122 +
       123 +      // Test with value usage in transformation
       124 +      fnWithValue := func(k string, v int) string {
       125 +        return fmt.Sprintf("%s_%d", k, v)
       126 +      }
       127 +      resultWithValue := xmap.MapKeys(m, fnWithValue)
       128 +      expectedWithValue := map[string]int{"a_1": 1, "b_2": 2, "c_3": 3}
       129 +      assert.Equal(t, expectedWithValue, resultWithValue)
       130 +
       131 +      // Test with empty map
       132 +      emptyMap := map[string]int{}
       133 +      emptyResult := xmap.MapKeys(emptyMap, fn)
       134 +      assert.Equal(t, map[string]int{}, emptyResult)
       135 +
       136 +      // Test with duplicate key generation (last one wins)
       137 +      m2 := map[int]string{1: "a", 2: "b", 3: "c"}
       138 +      fn2 := func(k int, v string) int {
       139 +        return k % 2 // This will create duplicate keys: 1%2=1, 2%2=0, 3%2=1
       140 +      }
       141 +      result2 := xmap.MapKeys(m2, fn2)
       142 +      // Should have keys 0 and 1, with values from the last occurrence of each key
       143 +      expected2 := map[int]string{0: "b", 1: "c"}
       144 +      assert.Equal(t, expected2, result2)
       145 +    })
       146    }
